### PR TITLE
fix: typos

### DIFF
--- a/hosts/milaptop/sound.nix
+++ b/hosts/milaptop/sound.nix
@@ -18,7 +18,7 @@ let
           set -euo pipefail
 
           # Copy original files, for each split-output (`out`, `dev` etc.).
-          # TODO: Remove hard coded refrence to pipewire so this function will
+          # TODO: Remove hard coded reference to pipewire so this function will
           #   work with any package.
           ${lib.concatStringsSep "\n" (
             map (outputName: ''

--- a/modules/home/apps/firefox-extensions.nix
+++ b/modules/home/apps/firefox-extensions.nix
@@ -94,7 +94,7 @@ in
               styleSystemControls = true;
               darkColorScheme = "default";
               lightColorScheme = "default";
-              immedateModify = false;
+              immediateModify = false;
             };
             disabledFor =
               # (lib.importJSON inputs.self.packages.${pkgs.system}.catppuccin-userstyles-domains)

--- a/modules/home/apps/firefox-settings.nix
+++ b/modules/home/apps/firefox-settings.nix
@@ -45,7 +45,7 @@ in
       "font.name.sans-serif.x-western" = "DejaVuSansM Nerd Font";
       "font.name.serif.x-western" = "DejaVuSansM Nerd Font";
 
-      # diable fullscreen notification
+      # disable fullscreen notification
       "full-screen-api.transition-duration.enter" = "0 0";
       "full-screen-api.transition-duration.leave" = "0 0";
       "full-screen-api.warning.delay" = -1;

--- a/modules/home/apps/obsidian.nix
+++ b/modules/home/apps/obsidian.nix
@@ -26,7 +26,7 @@ in
     home.packages = [ cfg.package ];
 
     # FIX: https://github.com/nix-community/home-manager/issues/7906
-    # TODO: configre
+    # TODO: configure
     # https://home-manager-options.extranix.com/?query=obsidian&release=release-25.11
     # https://github.com/RandomNEET/nixos/blob/b0f78c396d759e88f13dddead4a2e6d507cbe4a7/modules/programs/gui/obsidian/default.nix
     # https://github.com/RandomNEET/nixos/blob/b0f78c396d759e88f13dddead4a2e6d507cbe4a7/pkgs/obsidian-catppuccin/default.nix

--- a/modules/home/system/catppuccin.nix
+++ b/modules/home/system/catppuccin.nix
@@ -33,12 +33,12 @@ in
       hyprlock.enable = false; # not using colors
       spotify-player.enable = false; # default theme looks better in themed terminal
 
-      # NOTE: override mpv backgroud
+      # NOTE: override mpv background
       # https://github.com/catppuccin/nix/issues/468
       sources.mpv =
         inputs.catppuccin.packages.${pkgs.stdenv.hostPlatform.system}.mpv.overrideAttrs
           (oldAttrs: {
-            postPatch = (oldAttrs.postPach or "") + ''
+            postPatch = (oldAttrs.postPatch or "") + ''
               substituteInPlace "themes/${config.catppuccin.mpv.flavor}/${config.catppuccin.mpv.accent}.conf" \
                 --replace-fail "background-color='#1e1e2e'" "background-color='#000000'"
             '';

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -1,4 +1,4 @@
-# TODO: cleanup exessive config
+# TODO: cleanup excessive config
 {
   config,
   lib,


### PR DESCRIPTION
When setting up `typos` for my personal config, I noticed that `immedateModify` was a typo'd version of `immediateModify`, so i fixed it in my configuration and remembered you had it here too, so i ran typos here and found some other typos and fixed them. You're welcome!